### PR TITLE
Update package to include new app-manifest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -143,9 +143,9 @@
             }
         },
         "@bookingbug/app-manifest": {
-            "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/@bookingbug/app-manifest/-/app-manifest-0.0.4.tgz",
-            "integrity": "sha512-OE0kE4Hg9P+pf99260AqmtBIOOjd+hXQqnipEtTVNQUqK9AX+qvxQwMoxb+OEcb24Fo/wA8BBmdMr6dz5zsh2A=="
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/@bookingbug/app-manifest/-/app-manifest-0.0.5.tgz",
+            "integrity": "sha512-+LBG2vCnM62c7UDloaNYQa599bH62olJ1T/VswOjwlL8bNISIy0rnScmTJsmLVAWcOnUICLTYfncKbsif5xjFw=="
         },
         "@vue/component-compiler-utils": {
             "version": "3.1.2",
@@ -3016,7 +3016,8 @@
                 },
                 "ansi-regex": {
                     "version": "2.1.1",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -3034,11 +3035,13 @@
                 },
                 "balanced-match": {
                     "version": "1.0.0",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -3051,15 +3054,18 @@
                 },
                 "code-point-at": {
                     "version": "1.1.0",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -3162,7 +3168,8 @@
                 },
                 "inherits": {
                     "version": "2.0.3",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -3172,6 +3179,7 @@
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -3184,17 +3192,20 @@
                 "minimatch": {
                     "version": "3.0.4",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
                 },
                 "minimist": {
                     "version": "0.0.8",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -3211,6 +3222,7 @@
                 "mkdirp": {
                     "version": "0.5.1",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -3283,7 +3295,8 @@
                 },
                 "number-is-nan": {
                     "version": "1.0.1",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -3293,6 +3306,7 @@
                 "once": {
                     "version": "1.4.0",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -3368,7 +3382,8 @@
                 },
                 "safe-buffer": {
                     "version": "5.1.2",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -3398,6 +3413,7 @@
                 "string-width": {
                     "version": "1.0.2",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -3415,6 +3431,7 @@
                 "strip-ansi": {
                     "version": "3.0.1",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -3453,11 +3470,13 @@
                 },
                 "wrappy": {
                     "version": "1.0.2",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.0.3",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "dev@jrni.com",
   "license": "ISC",
   "dependencies": {
-    "@bookingbug/app-manifest": "0.0.4",
+    "@bookingbug/app-manifest": "0.0.5",
     "ajv": "^6.6.2",
     "archiver": "^3.0.0",
     "aws-sdk": "^2.761.0",


### PR DESCRIPTION
This also removes the problematic vue-compiler that seems to not be used anywhere? 